### PR TITLE
Cleanup Roact types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 export = Roact;
 export as namespace Roact;
 declare namespace Roact {
-	type Template<T extends GuiBase = GuiObject> = Partial<SubType<T, PropertyTypes>>;
+	type Template<T extends GuiBase = GuiObject> = GetProperties<T>;
 
 	//const Portal: Roact.Component<{}, PortalProps>;
 
@@ -289,16 +289,8 @@ class MyComponent extends Roact.Component<MyProps> {
 
 	const Children: unique symbol;
 
-	type P = Exclude<Instance, "Parent">;
-	/**
-	 * Properties of the specified instance
-	 */
-	type Properties<T extends Instance> = ExcludeReadonlyProps<Partial<SubType<T, PropertyTypes>>>;
-
-	type JsxIntrinsic<T extends Instance> = Properties<T> & RbxJsxIntrinsicProps<T>;
-	type JsxLayerCollector<T extends LayerCollector> = JsxIntrinsic<T>;
-	type JsxUIComponent<T extends UIComponent> = JsxIntrinsic<T>;
-	type JsxGuiObject<T extends GuiObject> = Properties<T> & RefProps<T, GuiObject> & RbxJsxIntrinsicProps<T>;
+	type JsxObject<T extends Instance> = { [P in Exclude<GetWritableProperties<T>, "Parent" | "Name">]?: T[P] } &
+		RbxJsxIntrinsicProps<T>;
 }
 
 declare global {
@@ -321,33 +313,33 @@ declare global {
 		interface IntrinsicClassAttributes<T extends Instance> extends RbxJsxProps {}
 
 		interface IntrinsicElements {
-			uiaspectratioconstraint: Roact.JsxUIComponent<UIAspectRatioConstraint>;
+			uiaspectratioconstraint: Roact.JsxObject<UIAspectRatioConstraint>;
 
-			screengui: Roact.JsxLayerCollector<ScreenGui>;
-			billboardgui: Roact.JsxLayerCollector<BillboardGui>;
-			surfacegui: Roact.JsxLayerCollector<SurfaceGui>;
+			screengui: Roact.JsxObject<ScreenGui>;
+			billboardgui: Roact.JsxObject<BillboardGui>;
+			surfacegui: Roact.JsxObject<SurfaceGui>;
 
-			imagelabel: Roact.JsxGuiObject<ImageLabel>;
-			imagebutton: Roact.JsxGuiObject<ImageButton>;
+			imagelabel: Roact.JsxObject<ImageLabel>;
+			imagebutton: Roact.JsxObject<ImageButton>;
 
-			textlabel: Roact.JsxGuiObject<TextLabel>;
-			textbutton: Roact.JsxGuiObject<TextButton>;
-			textbox: Roact.JsxGuiObject<TextBox>;
+			textlabel: Roact.JsxObject<TextLabel>;
+			textbutton: Roact.JsxObject<TextButton>;
+			textbox: Roact.JsxObject<TextBox>;
 
-			frame: Roact.JsxGuiObject<Frame>;
-			viewportframe: Roact.JsxGuiObject<ViewportFrame>;
-			scrollingframe: Roact.JsxGuiObject<ScrollingFrame>;
+			frame: Roact.JsxObject<Frame>;
+			viewportframe: Roact.JsxObject<ViewportFrame>;
+			scrollingframe: Roact.JsxObject<ScrollingFrame>;
 
-			uigridlayout: Roact.JsxUIComponent<UIGridLayout>;
-			uilistlayout: Roact.JsxUIComponent<UIListLayout>;
-			uipagelayout: Roact.JsxUIComponent<UIPageLayout>;
-			uitablelayout: Roact.JsxUIComponent<UITableLayout>;
+			uigridlayout: Roact.JsxObject<UIGridLayout>;
+			uilistlayout: Roact.JsxObject<UIListLayout>;
+			uipagelayout: Roact.JsxObject<UIPageLayout>;
+			uitablelayout: Roact.JsxObject<UITableLayout>;
 
-			uipadding: Roact.JsxUIComponent<UIPadding>;
-			uiscale: Roact.JsxUIComponent<UIScale>;
+			uipadding: Roact.JsxObject<UIPadding>;
+			uiscale: Roact.JsxObject<UIScale>;
 
-			uisizeconstraint: Roact.JsxUIComponent<UISizeConstraint>;
-			uitextsizeconstraint: Roact.JsxUIComponent<UITextSizeConstraint>;
+			uisizeconstraint: Roact.JsxObject<UISizeConstraint>;
+			uitextsizeconstraint: Roact.JsxObject<UITextSizeConstraint>;
 		}
 	}
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -289,7 +289,7 @@ class MyComponent extends Roact.Component<MyProps> {
 
 	const Children: unique symbol;
 
-	type JsxObject<T extends Instance> = { [P in Exclude<GetWritableProperties<T>, "Parent" | "Name">]?: T[P] } &
+	type JsxObject<T extends Instance> = Partial<Pick<T, Exclude<GetWritableProperties<T>, "Parent" | "Name">>> &
 		RbxJsxIntrinsicProps<T>;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 export = Roact;
 export as namespace Roact;
 declare namespace Roact {
-	type Template<T extends GuiBase = GuiObject> = GetProperties<T>;
+	type Template<T extends GuiBase = GuiObject> = Partial<Pick<T, GetProperties<T>>>;
 
 	//const Portal: Roact.Component<{}, PortalProps>;
 

--- a/internal.d.ts
+++ b/internal.d.ts
@@ -127,7 +127,7 @@ type RoactEvents<T> = {
 		: never
 };
 
-type RoactPropertyChanges<T extends Instance> = { [key in keyof GetWritableProperties<T>]: (rbx: T) => void };
+type RoactPropertyChanges<T extends Instance> = { [key in GetWritableProperties<T>]?: (rbx: T) => void };
 
 interface RoactEventSymbol {
 	readonly [name: string]: symbol;

--- a/internal.d.ts
+++ b/internal.d.ts
@@ -2,7 +2,7 @@ type FunctionalComponent<T, P> = T extends ((props: P) => Roact.Element) ? T : n
 type StatefulComponent<T, P = {}> = T extends Roact.RenderablePropsClass<P> ? T : never;
 type PrimitiveComponent<T> = T extends keyof CreatableInstances ? T : never;
 
-type PrimitiveProperties<T extends keyof CreatableInstances> = Partial<GetWritableProperties<CreatableInstances[T]>> & {
+type PrimitiveProperties<T extends keyof CreatableInstances> = Partial<Pick<CreatableInstances[T], GetWritableProperties<CreatableInstances[T]>>> & {
 	[Roact.Ref]?: Roact.Ref<CreatableInstances[T]> | Roact.Ref | ((ref: CreatableInstances[T]) => void);
 };
 

--- a/internal.d.ts
+++ b/internal.d.ts
@@ -122,7 +122,7 @@ interface PortalProps {
 }
 
 type RoactEvents<T> = {
-	[K in keyof SubType<T, RBXScriptSignal>]: T[K] extends RBXScriptSignal<infer F>
+	[K in keyof SubType<T, RBXScriptSignal>]?: T[K] extends RBXScriptSignal<infer F>
 		? EventHandlerFunction<T, FunctionArguments<F>>
 		: never
 };

--- a/internal.d.ts
+++ b/internal.d.ts
@@ -1,48 +1,14 @@
-type ValuesOf<T> = T extends Instance ? Partial<T> : never;
-
-type Writable2<T> = Pick<
-	T,
-	{
-		[P in keyof T]-?: (<U>() => U extends { [Q in P]: T[P] } ? 1 : 2) extends (<U>() => U extends {
-			-readonly [Q in P]: T[P]
-		}
-			? 1
-			: 2)
-			? P
-			: never
-	}[keyof T]
->;
-type Key = string | number;
 type FunctionalComponent<T, P> = T extends ((props: P) => Roact.Element) ? T : never;
 type StatefulComponent<T, P = {}> = T extends Roact.RenderablePropsClass<P> ? T : never;
 type PrimitiveComponent<T> = T extends keyof CreatableInstances ? T : never;
 
-type WithRef<T extends Instance> = { [Roact.Ref]?: Roact.Ref<T> | Roact.Ref | ((ref: T) => void) };
+type PrimitiveProperties<T extends keyof CreatableInstances> = Partial<GetWritableProperties<CreatableInstances[T]>> & {
+	[Roact.Ref]?: Roact.Ref<CreatableInstances[T]> | Roact.Ref | ((ref: CreatableInstances[T]) => void);
+};
 
-type PrimitiveProperties<T extends keyof CreatableInstances> = Writable2<Partial<CreatableInstances[T]>> &
-	WithRef<CreatableInstances[T]>;
 /// <reference path="index.d.ts" />
 
 interface RoactSymbol {}
-
-type Without<T, K> = Pick<T, Exclude<keyof T, K>>;
-
-type RefProps<T extends Instance, V extends Instance> = ExcludeReadonlyProps<
-	CustomPartial<SubType<T, RefablePropertyTypes>, Roact.Ref<V>>
->;
-
-type CustomPartial<T, V> = { [P in keyof T]?: T[P] | V };
-
-type ReadonlyProps = "Parent" | "Name" | "ClassName";
-type ReadonlyGuiProps =
-	| "IsLoaded"
-	| "AbsoluteRotation"
-	| "AbsolutePosition"
-	| "AbsoluteSize"
-	| "TextFits"
-	| "TextBounds";
-
-type ExcludeReadonlyProps<T> = Without<T, ReadonlyProps | ReadonlyGuiProps>;
 
 interface RbxJsxProps {
 	/**
@@ -55,7 +21,7 @@ Roact.createElement(Parent, {...}, {
     Bob = Roact.createElement(ThisElement, {...})
 })```
      */
-	Key?: Key;
+	Key?: string | number;
 }
 
 /**
@@ -156,12 +122,12 @@ interface PortalProps {
 }
 
 type RoactEvents<T> = {
-	[K in keyof Partial<SubType<T, RBXScriptSignal>>]: T[K] extends RBXScriptSignal<infer F>
+	[K in keyof SubType<T, RBXScriptSignal>]: T[K] extends RBXScriptSignal<infer F>
 		? EventHandlerFunction<T, FunctionArguments<F>>
 		: never
 };
 
-type RoactPropertyChanges<T> = { [key in keyof Partial<SubType<T, PropertyTypes>>]: PropertyChangeHandlerFunction<T> };
+type RoactPropertyChanges<T extends Instance> = { [key in keyof GetWritableProperties<T>]: (rbx: T) => void };
 
 interface RoactEventSymbol {
 	readonly [name: string]: symbol;
@@ -196,34 +162,7 @@ type EventHandlerFunction<T, U extends any[]> = U extends []
 	? (rbx: T, a: A, b: B, c: C, d: D, e: E, f: F) => void
 	: (rbx: T, ...args: unknown[]) => void;
 
-type PropertyChangeHandlerFunction<T> = (rbx: T) => void;
-
-type RefablePropertyTypes = Instance;
-
-type PropertyTypes =
-	| string
-	| number
-	| Vector2
-	| Vector3
-	| CFrame
-	| UDim2
-	| UDim
-	| Axes
-	| BrickColor
-	| ColorSequence
-	| Vector2int16
-	| Vector3int16
-	| Region3
-	| Region3int16
-	| PhysicalProperties
-	| Rect
-	| Color3
-	| Faces
-	| ReflectionMetadataEnums
-	| boolean;
-
-type FilterFlags<Base, Condition> = { [Key in keyof Base]: Base[Key] extends Condition ? Key : never };
-
-type AllowedNames<Base, Condition> = FilterFlags<Base, Condition>[keyof Base];
-
-type SubType<Base, Condition> = Pick<Base, AllowedNames<Base, Condition>>;
+type SubType<Base, Condition> = Pick<
+	Base,
+	{ [Key in keyof Base]: Base[Key] extends Condition ? Key : never }[keyof Base]
+>;


### PR DESCRIPTION
- Remove members which seem unnecessary
- Make all non-writable properties blocked
- Allow all writable properties to be settable (except Parent/Name)

I don't know what `Roact.Template` is for. I just guessed what it should be.

Fixes https://github.com/roblox-ts/rbx-roact/issues/10