### PR TITLE
Fix type of `RoactBinding<T>.map` to return a `RoactBinding<R>` instead of `R`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -186,7 +186,7 @@ declare namespace Roact {
 	function oneChild(children?: Element[]): Roact.Element;
 
 	interface RoactBinding<T> {
-		map<R>(valueTransform: (value: T) => R): R;
+		map<R>(valueTransform: (value: T) => R): RoactBinding<R>;
 		getValue(): T;
 	}
 


### PR DESCRIPTION
The type was inaccurate to the implementation, this should fix it.