### PR TITLE
Syntax error in the README Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- <div align="center"><img src="https://australis.dev/roact-tsx.png?v=3"/></div> -->
+<div align="center"><img src="https://australis.dev/roact-tsx.png?v=3"/></div>
 <h1 align="center">Roact-TS</h1>
 <div align="center">
 	<a href="https://roblox.github.io/roact">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center"><img src="https://australis.dev/roact-tsx.png?v=3"/></div>
+<!-- <div align="center"><img src="https://australis.dev/roact-tsx.png?v=3"/></div> -->
 <h1 align="center">Roact-TS</h1>
 <div align="center">
 	<a href="https://roblox.github.io/roact">
@@ -49,7 +49,7 @@ const tree = Roact.createElement("ScreenGui", {}, {
   Label: Roact.createElement("TextLabel", {
     Text: "Hello, World!",
     Size: new UDim2(1, 0, 1, 0)
-  });
+  }),
 });
 
 Roact.mount(tree, PlayerGui, "HelloWorld");


### PR DESCRIPTION
The first example has a small syntax error, using `;` instead of `,`. 