### PR TITLE
fix link to original roact license

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ Roact.mount(tree, PlayerGui, "HelloWorld");
 ```
 
 ## License
-The original Roact library's License can be found here: [Roact License](https://github.com/Roblox/roact/blob/master/LICENSE)
+The original Roact library's License can be found here: [Roact License](https://github.com/Roblox/roact/blob/master/LICENSE.txt)

--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ Roact.mount(tree, PlayerGui, "HelloWorld");
 ```
 
 ## License
-The original Roact library's License can be found here: [Roact License](https://github.com/Roblox/roact/blob/master/LICENSE.txt)
+The original Roact library's License can be found here: [Roact License](https://github.com/Roblox/roact/blob/520f8e685ab174654c8b3a99c3f243cadadc1c7d/LICENSE.txt)


### PR DESCRIPTION
The current link is dead (because the file name is `LICENSE.txt`, not just `LICENSE`).